### PR TITLE
Release candidate 1

### DIFF
--- a/amazin-product-box/amazin-product-box-plugin.php
+++ b/amazin-product-box/amazin-product-box-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Amazin' Product Box
  * Plugin URI: http://majoh.dev
- * Description: Customizable product box for Amazon products with an affiliate link
+ * Description: Showcase your recommended products in your posts with eye-catching product boxes
  * Version: 1.0
  * Author: Mandi Grant
  * Author URI: http://majoh.dev
@@ -20,7 +20,7 @@ add_action( 'init', function() {
     wp_enqueue_script('admin', $jsurl, array( 'jquery' ), 1.1, true);
 
     $cssurl = plugin_dir_url(__FILE__) . 'styles.css';
-    wp_enqueue_style( 'amazin-stylesheet', $cssurl, array(), 1.30 );
+    wp_enqueue_style( 'amazin-stylesheet', $cssurl, array(), 1.31 );
 
     register_post_type('amazin_product_box',
         array(
@@ -41,8 +41,16 @@ add_action( 'init', function() {
     add_option( 'amazin_product_box_option_headline', 'We recommend');
     register_setting( 'amazin_product_box_options_group', 'amazin_product_box_option_headline', 'amazin_product_box_callback' );
 
+    add_filter( 'plugin_action_links_' . plugin_basename(__FILE__), 'add_plugin_action_links' );
+
     new Amazin_Product_Box_Admin_Menu();
 });
+
+function add_plugin_action_links( $links ) {
+    $plugin_url = admin_url( 'admin.php?page=amazinProductBox' );
+    $links[] = '<a href="' . $plugin_url . '">' . __( 'Manage Product Boxes', 'apb' ) . '</a>';
+    return $links;
+}
 
 function amazin_product_box_shortcode( $atts ) {
     $a = shortcode_atts( array(
@@ -78,7 +86,7 @@ function amazin_product_box_render_in_post($productBox) {
                 </div>
             </div>
             <div class="amazin-product-box-button-wrap">
-                <a href="<?php echo $content['productLink'] ?>" class="amazin-product-box-button"><?php echo $content['productButtonText'] ?></a>
+                <a href="<?php echo $content['productUrl'] ?>" class="amazin-product-box-button"><?php echo $content['productButtonText'] ?></a>
             </div>
         </div>
     <?php

--- a/amazin-product-box/amazin-product-box-plugin.php
+++ b/amazin-product-box/amazin-product-box-plugin.php
@@ -20,7 +20,7 @@ add_action( 'init', function() {
     wp_enqueue_script('admin', $jsurl, array( 'jquery' ), 1.1, true);
 
     $cssurl = plugin_dir_url(__FILE__) . 'styles.css';
-    wp_enqueue_style( 'amazin-stylesheet', $cssurl, array(), 1.31 );
+    wp_enqueue_style( 'amazin-stylesheet', $cssurl, array(), 1.32 );
 
     register_post_type('amazin_product_box',
         array(
@@ -39,7 +39,9 @@ add_action( 'init', function() {
     );
 
     add_option( 'amazin_product_box_option_headline', 'We recommend');
+    add_option( 'amazin_product_box_option_new_tab', false);
     register_setting( 'amazin_product_box_options_group', 'amazin_product_box_option_headline', 'amazin_product_box_callback' );
+    register_setting( 'amazin_product_box_options_group', 'amazin_product_box_option_new_tab', 'amazin_product_box_callback' );
 
     add_filter( 'plugin_action_links_' . plugin_basename(__FILE__), 'add_plugin_action_links' );
 
@@ -72,6 +74,8 @@ function amazin_product_box_render_in_post($productBox) {
     $productBoxTitle = $productBox->post_title;
     $stripped = stripslashes($productBox->post_content);
     $content = json_decode($stripped, true);
+    $newTab = get_option('amazin_product_box_option_new_tab') ? 'target="_blank"' : '';
+
     ?>
         <div class="amazin-product-box" id="<?php echo 'amazin-product-box-id-'.$id; ?>">
             <p class="amazin-product-box-recommend-text"><?php echo get_option('amazin_product_box_option_headline'); ?></p>
@@ -86,7 +90,7 @@ function amazin_product_box_render_in_post($productBox) {
                 </div>
             </div>
             <div class="amazin-product-box-button-wrap">
-                <a href="<?php echo $content['productUrl'] ?>" class="amazin-product-box-button"><?php echo $content['productButtonText'] ?></a>
+                <a href="<?php echo $content['productUrl'] ?>" class="amazin-product-box-button" <?php echo $newTab ?> ><?php echo $content['productButtonText'] ?></a>
             </div>
         </div>
     <?php

--- a/amazin-product-box/includes/views/product-box-edit.php
+++ b/amazin-product-box/includes/views/product-box-edit.php
@@ -39,9 +39,11 @@
                         <div class="upload">
                             <img data-src="<?php echo $phURL ?>" src="<?php echo $image; ?>" width="120px" height="120px" />
                             <div>
-                                <input type="hidden" name="Product-Image" id="Product-Image" value="" />
+                                <input type="hidden" name="Product-Image" id="Product-Image" value="<?php echo $content['productImage'] ?>" />
                                 <button type="submit" class="upload_image_button button"><?php _e( 'Upload/Choose', 'apb' ); ?></button>
                                 <button type="submit" class="remove_image_button button"><?php _e( 'Clear', 'apb' ); ?></button>
+                                <br/>
+                                <span class="description"><?php _e('Choose an image that is large (at least 1000x1000 pixels) and square', 'apb' ); ?></span>
                             </div>
                         </div>
                     </td>

--- a/amazin-product-box/includes/views/product-box-list.php
+++ b/amazin-product-box/includes/views/product-box-list.php
@@ -21,20 +21,36 @@
     </form>
 
     <form method="post" action="options.php">
-        <?php settings_fields( 'amazin_product_box_options_group' ); ?>
+        <?php
+
+            $options = settings_fields( 'amazin_product_box_options_group' );
+            $newTab = get_option('amazin_product_box_option_new_tab') ? 'checked' : ''; //$options['amazin_product_box_new_tab'];
+        ?>
         <h3>Product box settings</h3>
         <p>These settings are shared by all product boxes on your site.</p>
-        <table>
-            <tr valign="top">
-                <th scope="row">
-                    <label for="amazin_product_box_option_headline">Product Box Headline</label>
-                </th>
-            <td>
-                <input type="text" id="amazin_product_box_option_headline" name="amazin_product_box_option_headline" value="<?php echo get_option('amazin_product_box_option_headline'); ?>" />
-                <br/>
-                <span class="description"><?php _e('Examples: "We recommend", "Our pick", "A Sitename Favorite", etc.', 'apb' ); ?></span>
-            </td>
-            </tr>
+        <table class="form-table">
+            <tbody>
+                <tr>
+                    <th scope="row">
+                        <label for="amazin_product_box_option_headline">Product Box headline</label>
+                    </th>
+                    <td>
+                        <input type="text" id="amazin_product_box_option_headline" name="amazin_product_box_option_headline" value="<?php echo get_option('amazin_product_box_option_headline'); ?>" />
+                        <br/>
+                        <span class="description"><?php _e('Examples: "We recommend", "Our pick", "A Sitename Favorite", etc.', 'apb' ); ?></span>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row">
+                        <label for="amazin_product_box_option_new_tab">Open link in new tab</label>
+                    </th>
+                    <td>
+                        <input type="checkbox" id="amazin_product_box_option_new_tab" name="amazin_product_box_option_new_tab" value="newTab" <?php checked( 'newTab', get_option('amazin_product_box_option_new_tab') ); ?> />
+                        <br/>
+                        <span class="description"><?php _e('The button link should open in a new browser tab', 'apb' ); ?></span>
+                    </td>
+                </tr>
+            </tbody>
         </table>
         <?php  submit_button(); ?>
     </form>

--- a/amazin-product-box/includes/views/product-box-new.php
+++ b/amazin-product-box/includes/views/product-box-new.php
@@ -33,6 +33,8 @@
                                 <input type="hidden" name="Product-Image" id="Product-Image" value="" />
                                 <button type="submit" class="upload_image_button button"><?php _e( 'Upload/Choose', 'apb' ); ?></button>
                                 <button type="submit" class="remove_image_button button"><?php _e( 'Clear', 'apb' ); ?></button>
+                                <br/>
+                                <span class="description"><?php _e('Choose an image that is large (at least 1000x1000 pixels) and square', 'apb' ); ?></span>
                             </div>
                         </div>
                     </td>

--- a/amazin-product-box/styles.css
+++ b/amazin-product-box/styles.css
@@ -3,8 +3,8 @@
     border:1px solid grey;
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
     padding:28px;
-    /* width:700px; */ /* uncomment to center in post */
-    /* margin:0 auto !important;*/ /* uncomment to center in post */
+    width:80%;
+    margin:0 auto !important;
 }
 
 .amazin-product-box-column {

--- a/amazin-product-box/uninstall.php
+++ b/amazin-product-box/uninstall.php
@@ -4,12 +4,13 @@ if (!defined('WP_UNINSTALL_PLUGIN')) {
     die;
 }
 
-$option_name = 'amazin_product_box_option_headline';
+$option_names = array('amazin_product_box_option_headline', 'amazin_product_box_option_new_tab');
+foreach ($option_names as $option_name) {
+    delete_option($option_name);
 
-delete_option($option_name);
-
-// for site options in Multisite
-delete_site_option($option_name);
+    // for site options in Multisite
+    delete_site_option($option_name);
+}
 
 // drop a custom database table
 global $wpdb;


### PR DESCRIPTION
[Bug fix] - Editing a product box with an existing image now retains the existing saved image
[Improvement] - Image upload help text added to Edit and New forms
[Improvement] - Added a "plugin action link" that goes directly to Amazin' Product Box management page via the plugin's entry in the plugins page 
[Bug fix] - Button actually goes to the user's link now
[Improvement] - Added a setting for whether the button should open the link in a new tab or stay in the same tab 
[Improvement] - Product Box is now narrower than the post (I think it looks nicer that way)